### PR TITLE
Set the session to secure on HTTPS

### DIFF
--- a/plugins/Cosign/CosignPlugin.php
+++ b/plugins/Cosign/CosignPlugin.php
@@ -18,7 +18,7 @@ class CosignPlugin extends Omeka_Plugin_AbstractPlugin
     public function __construct()
     {
         parent::__construct();
-        if (isset($_SERVER['REMOTE_USER'])) {
+        if (!empty($_SERVER['HTTPS'])) {
             /**
             * When logged in, we want to ensure that we're using secure cookies.
             *


### PR DESCRIPTION
Our reverse proxy situation made apache unaware that it was supposed
to be delivering secure cookies.  In the past REMOTE_USER was an
acceptable indicator, but that's no longer the case.  Our apache
config is more consistent about setting HTTPS now.