### PR TITLE
First updates to the index page panel layout.

### DIFF
--- a/themes/mlibrary_new/css/style.css
+++ b/themes/mlibrary_new/css/style.css
@@ -224,11 +224,39 @@ div.browse-index {
   width: calc(100% - 1.5em);
 }
 
-.index-exhibits h3.panel-card-title {
-  padding: .5em;
+.index-featured-exhibit .panel-heading  {
+  position: relative;
+  height: 30em;
+  width: 100%;
+  overflow: hidden;
 }
 
-.index-exhibits h3.panel-card-title a {
+.index-exhibits .panel-heading  {
+  position: relative;
+  height: 15em;
+  width: 100%;
+  overflow: hidden;
+}
+
+.index-exhibits .image-card,
+.index-featured-exhibit .image-card {
+   width: 100%;
+   height: auto;
+   overflow: hidden;
+}
+
+.index-featured-exhibit-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+}
+
+.index-exhibits .panel-body,
+.index-featured-exhibit .panel-body {
+    padding: 1em;
+}
+
+.index-exhibits h3.panel-card-title a, .index-featured-exhibit h3.panel-card-title a  {
   color: #3D3D3D;
 }
 
@@ -501,6 +529,12 @@ body>.navbar {
     padding-bottom: .5em;
     margin: 0 auto;
   }
+
+  .index-exhibits {
+  margin: .75em;
+  width: calc(100% - 1.5em);
+}
+
 }
 
 #sort-links-list {

--- a/themes/mlibrary_new/custom.php
+++ b/themes/mlibrary_new/custom.php
@@ -81,7 +81,7 @@ function mlibrary_display_exhibit_type_of_item($rawAttachment)
 
 function mlibrary_exhibit_builder_display_random_featured_exhibit()
 {
-    $html = '<div id="featured-exhibit"><h2>Featured Exhibits</h2>';
+    $html = '<div id="featured-exhibit" class="featured-exhibit-container">';
     $featuredExhibit = exhibit_builder_random_featured_exhibit();
     if ($featuredExhibit) {
         $html .= get_view()->partial('exhibit-builder/exhibits/single.php', array('exhibit' => $featuredExhibit));

--- a/themes/mlibrary_new/exhibit-builder/exhibits/card.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/card.php
@@ -1,4 +1,8 @@
-<div class ="exhibit record">
-  <?php echo $exhibitImage; ?>
-  <h3><?php echo link_to($exhibit, 'show', strip_formatting($title)); ?></h3>
-</div>
+	<div class ="exhibit record panel panel-default index-exhibits">
+		<div class="panel-heading">
+			<?php echo $exhibitImage; ?>
+		</div>
+		<div class ="card-info panel-body">
+	  	<h3 class="panel-card-title"><?php echo link_to($exhibit, 'show', strip_formatting($title)); ?></h3>
+		</div>
+	</div>

--- a/themes/mlibrary_new/exhibit-builder/exhibits/single.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/single.php
@@ -1,7 +1,11 @@
-<div class="exhibit record">
-<?php if ($exhibitImage = record_image($exhibit,'original',array('class' => 'feature-banner-image'))):
-         echo exhibit_builder_link_to_exhibit($exhibit, $exhibitImage); 
-      endif; ?>
-<h3><?php echo exhibit_builder_link_to_exhibit($exhibit); ?></h3>    
-<p><?php echo snippet_by_word_count(metadata($exhibit, 'description', array('no_escape' => true))); ?></p>
+<div class="exhibit record panel panel-default index-featured-exhibit">
+	<div class="panel-heading">
+		<?php if ($exhibitImage = record_image($exhibit,'original',array('class' => 'feature-banner-image'))):
+	         echo exhibit_builder_link_to_exhibit($exhibit, $exhibitImage); 
+	      endif; ?>
+	</div>
+	<div class="card-info panel-body">
+		<h3 class="panel-card-title"><?php echo exhibit_builder_link_to_exhibit($exhibit); ?></h3>    
+		<p class="panel-card-text"><?php echo snippet_by_word_count(metadata($exhibit, 'description', array('no_escape' => true))); ?></p>
+	</div>
 </div>

--- a/themes/mlibrary_new/index.php
+++ b/themes/mlibrary_new/index.php
@@ -1,65 +1,55 @@
 <?php 
         set_theme_option('display_header','1');
 	echo head(array('bodyid'=>'home')); 
-	$sidebar_pos=get_theme_option('sidebar_position');
-	$main_add="";
-	$sidebar_add="";
-	if($sidebar_pos=='left'){
-		$main_add=" col-md-push-4";
-		$sidebar_add=" col-md-pull-8";
-		}		
 ?>
 <div class="row">
-    <div class="col-md-8<?php echo $main_add;?>">
-		<?php if ($homepageText = get_theme_option('Homepage Text')): ?>
-			<div id="homepage-text"><p><?php echo $homepageText; ?></p></div>
-		<?php else: ?>
-		<?php echo $this->partial('common/loremize-main.phtml');?>
-		<?php endif; ?>
-
+    <div class="col-xs-12">
+    <div class="row detail-nav">
+    	<div class="col-xs-12 ">
+    		<div class="col-xs-12 col-sm-6">
+    			<ul>
+    			<li class="detail-nav-heading">Browse</li>
+    			<li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+    			<li><a href="<?php echo url('exhibits'); ?>">Browse online exhibits</a></li>
+    			</ul>
+	    	</div>
+	    	<div class="col-xs-12 col-sm-6">
+	    		<ul>
+    			<li class="detail-nav-heading">About</li>
+    			<li>Etiam porta sem malesuada magna mollis euismod.</li>
+    			<li><a href="<?php echo url('about'); ?>">About online exhibits</a></li>
+    			</ul>
+	    	</div>
+    	</div>
+    </div>
+    <div class="col-xs-12 ">
+      <div class="detail-nav-border"><hr></div>
+    </div>
     </div>
 
-         <nav id="top-nav" class="top" role="navigation">
-            <?php echo public_nav_main(); ?>
-        </nav>
-    
-    <div class="col-md-4<?php echo $sidebar_add;?>">
-		<?php if (get_theme_option('display_sidebar_menu') !== '0'): ?>
-			<?php echo public_nav_sidebar_bootstrap(); ?>
-		<?php endif; ?>
-		<?php if (get_theme_option('display_sidebar_advanced_search') !== '0'): ?>
-			<div id="search-container">
-				<h2>Search</h2>
-				<?php echo search_form(array('show_advanced' => true)); ?>
-			</div>
-		<?php endif; ?>		
-        <?php if (get_theme_option('Display Featured Item') !== '0'): ?>
-			<div class="panel panel-default">
-				<div class="panel-heading"><span class="lead"><?php echo __('Featured Item'); ?></span></div>
-				<div class="panel-body"><?php echo random_featured_items(1); ?></div>
-			</div>           
-        <?php endif; ?>		
-        <?php if (get_theme_option('Display Featured Collection') !== '0'): ?>
-			<div class="panel panel-default">
-				<div class="panel-heading"><span class="lead"><?php echo __('Featured Collection'); ?></span></div>
-				<div class="panel-body"><?php echo random_featured_collection(); ?></div>
-			</div>
-        <?php endif; ?>
-        <?php if ((get_theme_option('Display Featured Exhibit') !== '0') && plugin_is_active('ExhibitBuilder') && function_exists('mlibrary_exhibit_builder_display_random_featured_exhibit')): ?>
-              <?php echo mlibrary_exhibit_builder_display_random_featured_exhibit(); ?>           
-        <?php endif; ?>
+    <div class="col-xs-12">
+      <h2 class="text-center">Featured Exhibits</h2>
     </div>
-</div>
-       <div>
+    <div class="col-xs-12">	
+        
+        <?php echo mlibrary_exhibit_builder_display_random_featured_exhibit(); ?>           
+     </div>
+  
+       <div class="col-xs-12 index-exhibits-container">
          <?php
            if (plugin_is_active('ExhibitBuilder') && function_exists('recent_exhibits_bootstrap')) { 
               echo recent_exhibits_bootstrap(4);
            }?>
        </div>
-    <div>
-      <a href="<?php echo url('exhibits'); ?>">Browse All Exhibits</a>
+
+  </div>
+
+    <div class="browse-index">
+      <div class="button browse-btn"><a href="<?php echo url('exhibits'); ?>">See All Exhibits</a></div>
     </div>
+    
 </div>    
+</div>
 
 <?php fire_plugin_hook('public_home', array('view' => $this)); ?>
 


### PR DESCRIPTION
- Add the "panel" layouts used in the summary page to the index page. Creates the block, the heading, the title, and the panel caption.
- Added flex to the panels content for responsive design
- Added the Browse and About nav layout style
- Removed the extraneous code for the items that were removed from the config (sidebar, etc...)
-First attempt at the item image sizes. That'll be finalized in a separate ticket for image sizes in panels across Browse/Search, Exhibits, and the Index page.