### PR TITLE
Move nav styles and update mobile nav layout

### DIFF
--- a/plugins/ExhibitBuilder/helpers/ExhibitPageFunctions.php
+++ b/plugins/ExhibitBuilder/helpers/ExhibitPageFunctions.php
@@ -312,36 +312,19 @@ function exhibit_builder_page_summary($exhibitPage = null)
         $exhibitPage = get_current_record('exhibit_page');
     }
 
-    $html = '<li class="exhibit-nav-list-items">'
-          . '<a class="exhibit-nav-list-items" href="' . exhibit_builder_exhibit_uri(get_current_record('exhibit'), $exhibitPage) . '">'
+    $html = '<li>'
+          . '<a href="' . exhibit_builder_exhibit_uri(get_current_record('exhibit'), $exhibitPage) . '">'
           . metadata($exhibitPage, 'title') .'</a>';
 
     $children = $exhibitPage->getChildPages();
     if ($children) {
-        $html .= '<ul class="exhibit-nav-list-sub">';
+        $html .= '<ul>';
         foreach ($children as $child) {
             $html .= exhibit_builder_page_summary($child);
             release_object($child);
         }
         $html .= '</ul>';
     }
-    $html .= '</li>';
-    return $html;
-}
-
-/**
- * Get a list item for a page, no children showing
- */
-function exhibit_builder_pages($exhibitPage = null)
-{
-    if (!$exhibitPage) {
-        $exhibitPage = get_current_record('exhibit_page');
-    }
-
-    $html = '<li class="exhibit-nav-list-items">'
-          . '<a class="exhibit-nav-list-items" href="' . exhibit_builder_exhibit_uri(get_current_record('exhibit'), $exhibitPage) . '">'
-          . metadata($exhibitPage, 'title') .'</a>';
-
     $html .= '</li>';
     return $html;
 }

--- a/themes/mlibrary_new/css/style.css
+++ b/themes/mlibrary_new/css/style.css
@@ -12,11 +12,6 @@ clear: both;
 content: "";
 }
 
-.feature-banner-image {
-  width: 100%;
-  height: auto;
-}
-
 .exhibit.record {
   display: inline-block;
 }
@@ -165,82 +160,41 @@ a.twitter-share-button:after {
   font-size: 1.5em;
 }
 
-.exhibit-nav-list {
+#exhibit-pages {
   list-style: none;
   margin: 0;
   padding-right: .25em;
   font-size: 1.2em;
 }
 
-.exhibit-nav-list-items {
-  padding: .2em 0;
-  margin: 0;
+#exhibit-pages li {
+  margin: .45em 0;
+  padding: 0;
   color: #6E6E6E;
 }
 
-.exhibit-nav-list-sub {
+.exhibit-pages-summary li > ul {
+  display: none;
+}
+
+.exhibit-pages-show li > ul {
   list-style: none;
   margin: 0;
-  padding-right: .25em;
+  padding-left: .5em;
   font-size: 1em;
 }
 
-div.exhibit-overview.active {
-  color: #126DC1;
+#exhibit-pages .active {
   border-left: 4px solid #126DC1;
   padding-left: .25em;
 }
 
+#exhibit-pages .active > a {
+    color: #126DC1;
+}
+
 .exhibit-overview {
   padding-left: 0;
-}
-
-div.browse-index {
-  padding-top: 2em;
-  text-align: center;
-}
-
-.browse-btn a {
-  color: #fff;
-}
-
-.detail-nav-border {
-  border-bottom: 2px solid #CCCCCC;
-  margin-bottom: 1em;
-}
-
-.detail-nav ul {
-  list-style: none;
-  padding: 1.5em 0;
-  margin: 0;
-}
-
-.detail-nav-heading {
-  font-size: 1.25em;
-  color: ;
-}
-
-.detail-nav li {
-  padding: 0;
-  margin: 0;
-}
-
-.detail-nav li a {
-  text-decoration: underline;
-}
-
-.nav-text-inline-heading, .nav-text-inline-button  {
-  display: inline-block;
-}
-
-.affix {
-  top: 5px;
-  z-index: 9999 !important;
-  width: 250px;
-  }
-
-.affix-top {
-  top: 0px;
 }
 
 /** Exhibit Show/Summary Page **/
@@ -373,7 +327,55 @@ div.browse-index {
   padding: 0 .5em .5em;
 }
 
-/** Home Page Featured Panels **/
+/** Home Page & Featured Panels **/
+
+div.browse-index {
+  padding-top: 2em;
+  text-align: center;
+}
+
+.browse-btn a {
+  color: #fff;
+}
+
+.detail-nav-border {
+  border-bottom: 2px solid #CCCCCC;
+  margin-bottom: 1em;
+}
+
+.detail-nav ul {
+  list-style: none;
+  padding: 1.5em 0;
+  margin: 0;
+}
+
+.detail-nav-heading {
+  font-size: 1.25em;
+  color: ;
+}
+
+.detail-nav li {
+  padding: 0;
+  margin: 0;
+}
+
+.detail-nav li a {
+  text-decoration: underline;
+}
+
+.nav-text-inline-heading, .nav-text-inline-button  {
+  display: inline-block;
+}
+
+.affix {
+  top: 5px;
+  z-index: 9999 !important;
+  width: 250px;
+  }
+
+.affix-top {
+  top: 0px;
+}
 
 .index-exhibits-container {
   display: flex;
@@ -416,6 +418,11 @@ div.browse-index {
   height: 13em;
   width: 100%;
   overflow: hidden;
+}
+
+.feature-banner-image {
+  width: 100%;
+  height: auto;
 }
 
 .image-card {
@@ -788,6 +795,20 @@ body>.navbar {
   #exhibit-gallery-theme-item {
   width: calc(48%);
   }
+
+
+  .exhibit-navigation h3 {
+  font-size: 1.2em;
+  }
+
+  #exhibit-pages {
+  font-size: 1em;
+  width: 90%;
+  }
+  
+  .exhibit-pages-show li > ul {
+  font-size: 1em;
+  }
 }
 
 @media (min-width: 768px) {
@@ -878,6 +899,11 @@ body>.navbar {
 
   #exhibit-gallery-theme-item {
   width: calc(100%);
+  }
+
+  .index-featured-exhibit .panel-heading {
+    position: relative;
+    height: 13em;
   }
 
 }

--- a/themes/mlibrary_new/exhibit-builder/exhibits/show.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/show.php
@@ -46,7 +46,7 @@ else {
 
 <section class="row">
     <section>
-      <div class="col-sm-12 col-md-3">
+      <div class="col-xs-12 col-sm-3">
         <nav class="exhibit-navigation" data-spy="affix" data-offset-top="575" data-offset-bottom="100">
           <div class="nav-text-inline">
             <h3 class="nav-text-inline-heading">Exhibit Contents</h3>
@@ -56,7 +56,7 @@ else {
           </div>
 
           <div class="exhibit-overview collapse navbar-collapse" id="nav-toggle">
-            <ul id="exhibit-pages" class="exhibit-nav-list">
+            <ul id="exhibit-pages" class="exhibit-nav-list exhibit-pages-show">
               <?php echo link_to_exhibit('Introduction'); ?>
               <?php
                 $exhibit_page = get_current_record('exhibit_page', false);
@@ -72,7 +72,7 @@ else {
     </section>
 
   <section class="exhibit-content cf">
-    <div class="col-sm-12 col-md-9 show-wrapper">
+    <div class="col-xs-12 col-sm-9 show-wrapper">
       <h2 class="section-title--large">
         <?php
           set_current_record('exhibit_page', $exhibit_page);
@@ -96,7 +96,7 @@ else {
               }
          ?>
   </div> 
-  <div class="col-sm-12 col-md-9 col-md-offset-3 padding-0">
+  <div class="col-xs-12 col-sm-9 col-sm-offset-3 padding-0">
     <div class="section-nav">
           <?php $navigate_previous_exhibit = mlibrary_new_exhibit_builder_previous_link_to_exhibit($exhibit, $exhibit_page);?>
           <?php if (!empty($navigate_previous_exhibit)){ ?>  

--- a/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
@@ -42,7 +42,7 @@
 
   <div id="primary">
     <section>
-      <div class="col-xs-12 col-md-3">
+      <div class="col-xs-12 col-sm-3">
         <nav class="exhibit-navigation" data-spy="affix" data-offset-top="650" data-offset-bottom="100">
           <div class="nav-text-inline">
           <h3 class="nav-text-inline-heading">Exhibit Contents</h3>
@@ -51,12 +51,12 @@
             </button>
           </div>
         <div class="exhibit-overview collapse navbar-collapse" id="summary-nav-toggle">
-        <ul id="exhibit-pages" class="exhibit-nav-list">
-           <?php echo link_to_exhibit('Introduction'); ?>
+        <ul id="exhibit-pages" class="exhibit-nav-list exhibit-pages-summary">
+           <li class="active"><?php echo link_to_exhibit('Introduction'); ?></li>
           <?php
             set_exhibit_pages_for_loop_by_exhibit();
             foreach (loop('exhibit_page') as $exhibitPage) {
-              echo exhibit_builder_pages($exhibitPage);
+              echo exhibit_builder_page_summary($exhibitPage);
             }
           ?>
         </ul>
@@ -66,7 +66,7 @@
 
   <section id="summary-view" class="exhibit-content cf">
 
-    <div class="col-xs-12 col-md-9">
+    <div class="col-xs-12 col-sm-9">
       <h2 class="section-title--large"> Introduction </h2>
       <?php echo metadata('exhibit','description',array('no_escape' => true)); ?>
       <div class = "exhibit-theme">


### PR DESCRIPTION
Move styles out of the Exhibit Builder plugin, rearranged styles in main.css, and fix layout breakpoints for side nav in mobile view.