### PR TITLE
Mlibrary exhibit page upgrade

### DIFF
--- a/plugins/BlogLayout/BlogLayoutPlugin.php
+++ b/plugins/BlogLayout/BlogLayoutPlugin.php
@@ -7,20 +7,56 @@
 class BlogLayoutPlugin extends Omeka_Plugin_AbstractPlugin
 {
     protected $_filters = array('exhibit_layouts');
+    protected $_hooks = array('initialize');
+
+    public function hookInitialize() {
+           $db = get_db();
+           $update_new_theme = array(
+                      'theme' => 'mlibrary_new'
+           );         
+           
+           $db->update($db->exhibits, $update_new_theme,
+                array('theme = ?' => 'mlibrary'));
+                
+           $default_options = array(
+            'file-position' => 'center',
+            'file-size' => 'fullsize',
+            'captions-position' => 'left'
+           );
+           
+           $encodedOptions = json_encode($default_options);
+           $update_file_text = array(
+             'options' => $encodedOptions,
+              'layout' => 'single-image'
+           ); 
+           $update_file = array(
+             'options' => $encodedOptions,
+              'layout' => 'single-image'
+           );
+          $db->update($db->exhibit_page_blocks, $update_file_text,
+                array('layout = ?' =>'file-text'));
+          
+          $db->update($db->exhibit_page_blocks, $update_file,
+                array('layout = ?' =>'file'));  
+    }
 
     public function filterExhibitLayouts($layouts)
     {
-        $layouts['single-image'] = array(
+
+       $new_layouts = array();
+       $new_layouts['text'] = $layouts['text'];
+       $new_layouts['gallery'] = $layouts['gallery'];
+        $new_layouts['single-image'] = array(
             'name' => 'Single Image',
             'description' => 'Display single image centered with caption under text.'
         );
 
-        $layouts['double-image'] = array(
+        $new_layouts['double-image'] = array(
             'name' => 'Double images',
             'description' => 'Display double images centered with caption under text.'
         );
 
-        return $layouts;
+        return $new_layouts;
     }
 
 }

--- a/plugins/BlogLayout/BlogLayoutPlugin.php
+++ b/plugins/BlogLayout/BlogLayoutPlugin.php
@@ -16,7 +16,7 @@ class BlogLayoutPlugin extends Omeka_Plugin_AbstractPlugin
            );         
            
            $db->update($db->exhibits, $update_new_theme,
-                array('theme = ?' => 'mlibrary'));
+                array('theme != ?' => 'mlibrary_new'));
                 
            $default_options = array(
             'file-position' => 'center',


### PR DESCRIPTION
Migrate file-text block to Single image block
Migrate file block to Single image block
Migrate all exhibits using mlibrary theme to new_mlibrary theme
Remove file-text and file block from the Exhibit builder

Single image block by default display full size image, centered with caption to the left