### PR TITLE
remove the about card from the summary page of the exhibit

### DIFF
--- a/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
@@ -74,17 +74,18 @@
                foreach (loop('exhibit_page') as $exhibitPage) {?>
                                <?php
                                   if (metadata('exhibit_page','title')!= 'Gallery') {
-                                      $page_card_info = mlibrary_new_display_exhibit_card_info($exhibitPage);
-                                      if(!empty($page_card_info)) {
-                                        $uri = exhibit_builder_exhibit_uri($exhibit, $exhibitPage);?>
-                                         <div class="exhibit-theme-item panel panel-default">
-                                             <a href= <?php echo html_escape($uri);?> >
+                                      if (metadata('exhibit_page','title')!= 'About the Exhibit') {
+                                         $page_card_info = mlibrary_new_display_exhibit_card_info($exhibitPage);
+                                         if(!empty($page_card_info)) {
+                                            $uri = exhibit_builder_exhibit_uri($exhibit, $exhibitPage);?>
+                                            <div class="exhibit-theme-item panel panel-default">
+                                              <a href= <?php echo html_escape($uri);?> >
                                                <div class="panel-heading"><?php  echo $page_card_info["image"];?></div>
                                                <div class="card-info panel-body"><h3 class="panel-card-title"><?php echo html_escape($page_card_info["title"]);?></h3>
                                                <p class="panel-card-text"><?php echo html_escape($page_card_info["description"]);?></p></div>
                                              </a>                           
-                                         </div>
-                                    <?php }}}?>  
+                                            </div>
+                                    <?php }}}}?>  
       </div>
     </div>
   </section>


### PR DESCRIPTION
Remove the about card from the Exhibit summary page, only those pages with the title "About the Exhibit" otherwise, a default image will be displayed.

#186 