### PR TITLE
move the code for breadcrumb when exhibit oject available

### DIFF
--- a/themes/mlibrary_new/items/show.php
+++ b/themes/mlibrary_new/items/show.php
@@ -32,22 +32,20 @@
 
      $gallery_plugin_active = plugin_is_active('ExhibitGalleryPage');
 
-     $exhibit_image_gallery_set = isset($gallery_plugin_active)? $image_gallery_link : '';
-   }
+     $exhibit_image_gallery_set = isset($gallery_plugin_active)? $image_gallery_link : '';?>
+     <!--Breadcrumb Bar-->
+     <section class="row">
+      <div class="col-xs-12">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><?php echo link_to_home_page(__('Home')); ?></li>
+          <li class="breadcrumb-item"><?php echo metadata('exhibit','title',array('no_escape' => true)); ?></li>
+          <li class="breadcrumb-item active"><?php echo $item_title; ?></li>
+        </ol>
+      </div>
+     </section>
+     <!--End breadcrumb bar-->
+ <?php }?>
 
-?>
-
-<!--Breadcrumb Bar-->
-<section class="row">
-  <div class="col-xs-12">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><?php echo link_to_home_page(__('Home')); ?></li>
-        <li class="breadcrumb-item"><?php echo metadata('exhibit','title',array('no_escape' => true)); ?></li>
-        <li class="breadcrumb-item active"><?php echo $item_title; ?></li>
-      </ol>
-  </div>
-</section>
-<!--End breadcrumb bar-->
 
 <div class="col-xs-12">
 <h1 class="item-title"><?php echo $item_title; ?></h1>


### PR DESCRIPTION
Add a condition to check if item page is accessed from admin site. 
Stop display Next, Previous navigation and breadcrumb when access the item page from admin site.
