### PR TITLE
Fix .tif files in the gallery

### DIFF
--- a/themes/mlibrary_new/custom.php
+++ b/themes/mlibrary_new/custom.php
@@ -264,11 +264,21 @@ function mlibrary_new_get_image_card($rawAttachment = null, $alt = '')
             $alt
         );
     }
-    return record_image(
-        $rawAttachment->getFile(),
-        'original',
-        ['class' => 'image-card', 'alt' => $alt]
-    );
+    $file = $rawAttachment->getFile();
+    if ($file->has_derivative_image) {
+        $src = implode(
+          '/',
+          [WEB_FILES, 'fullsize', $file->getDerivativeFilename()]
+        );
+    }
+    else {
+        $src = implode('/', [WEB_FILES, 'fullsize', $file->filename]);
+    }
+    return '<img src="' .
+        htmlentities($src, ENT_QUOTES, 'UTF-8') .
+        '" alt="' .
+        htmlentities($alt, ENT_QUOTES, 'UTF-8') .
+        '" class="image-card">';
 }
 
 


### PR DESCRIPTION
Browsers don't render images uploaded as .tif or .tiff.  Omeka handles this by building derivatives on the files, but `record_image(...)` doesn't show derivative images.  Thus using `record_image(...)` results in images not being presented.  This change fixes that situation.