### PR TITLE
Move the css file for single and double layout

### DIFF
--- a/plugins/ExhibitBuilder/functions.php
+++ b/plugins/ExhibitBuilder/functions.php
@@ -386,27 +386,6 @@ function exhibit_builder_public_head($args)
 
     if ($module == 'exhibit-builder') {
         queue_css_file('exhibits');
-        $exhibitPage = get_current_record('exhibit_page', false);
-        if ($exhibitPage) {
-            $blocks = $exhibitPage->ExhibitPageBlocks;
-
-            $layouts = array();
-            foreach ($blocks as $block) {
-                $layout = $block->getLayout();
-                if (!array_key_exists($layout->id, $layouts)) {
-                    $layouts[$layout->id] = true;
-                    try {
-                        queue_css_url($layout->getAssetUrl('layout.css'));
-                    } catch (InvalidArgumentException $e) {
-                        // no CSS for this layout
-                    }
-                }
-            }
-            fire_plugin_hook('exhibit_builder_page_head', array(
-                'view' => $args['view'],
-                'layouts' => $layouts)
-            );
-        }
     }
 }
 

--- a/themes/mlibrary_new/css/style.css
+++ b/themes/mlibrary_new/css/style.css
@@ -1,4 +1,70 @@
 /** Base styles **/
+
+.layout-single-image {
+    width: 100%;
+}
+
+.layout-single-image > .exhibit-items {
+    vertical-align: top;
+    margin-bottom: 0;
+    padding: .5em .25em;
+    width: 100%;
+    float: left;
+}
+
+.layout-double-image  {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
+  -webkit-box-align: flex-start;
+      -ms-flex-align: flex-start;
+          align-items: flex-start;
+  justify-content: flex-start;
+}
+
+
+.layout-double-image > .exhibit-items {
+  width: 46%;
+  height: auto; 
+  padding: .5em .25em;
+}
+
+.layout-single-image .layout-double-image .exhibit-items .download-file {
+    clear: both;
+    border-bottom: 0;
+    overflow: visible;
+}
+
+.layout-single-image .layout-double-image .exhibit-items .fullsize img {
+    max-width: 100%;
+    margin-bottom: 1em;
+}
+
+.layout-single-image .layout-double-image .exhibit-items .exhibit-item-caption p {
+    margin: 0;
+    clear: both;
+}
+
+.layout-single-image .layout-double-image .exhibit-items .exhibit-item-caption {
+    text-align: left;
+}
+
+/**Media Queries for Blog Layout**/
+
+@media only screen and (max-width: 767px) {
+
+    .layout-double-image > .exhibit-items {
+    width: 100%;
+    height: auto; 
+    padding: .5em 0;
+}
+}
+
 p {
   font-size: 1.1em;
 }


### PR DESCRIPTION
 Move the css file for single and double layout into style CSS file for the mlibrary theme.

Still, the style for double images needs to be adjusted when images are big to be in one line.