### PR TITLE
#321 Update data-offset for menu nav

### DIFF
--- a/themes/mlibrary_new/exhibit-builder/exhibits/show.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/show.php
@@ -27,7 +27,7 @@ else {
 
   <section class="row">
     <div class="col-xs-12 col-sm-3">
-      <nav class="exhibit-navigation" data-spy="affix" data-offset-top="250" data-offset-bottom="120">
+      <nav class="exhibit-navigation" data-spy="affix" data-offset-top="315" data-offset-bottom="120">
         <div class="nav-text-inline">
           <h2 class="nav-text-inline-heading">Exhibit Contents</h2>
           <button class="navbar-toggler nav-text-inline-button" type="button" data-toggle="collapse" data-target="#nav-toggle" aria-controls="nav-toggle" aria-expanded="false" aria-label="Toggle navigation">

--- a/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
+++ b/themes/mlibrary_new/exhibit-builder/exhibits/summary.php
@@ -28,7 +28,7 @@
   
   <section class="exhibit-side-navigation">
       <div class="col-xs-12 col-sm-3">
-        <nav class="exhibit-navigation" data-spy="affix" data-offset-top="650" data-offset-bottom="120">
+        <nav class="exhibit-navigation" data-spy="affix" data-offset-top="815" data-offset-bottom="120">
           <div class="nav-text-inline">
           <h2 class="nav-text-inline-heading">Exhibit Contents</h2>
            <button class="navbar-toggler nav-text-inline-button" type="button" data-toggle="collapse" data-target="#summary-nav-toggle" aria-controls="nav-toggle" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Adding the alert message at the top of the site resulted in a menu/title overlap. I adjusted the data-offset to fix the issue on the summary and show pages. 